### PR TITLE
Query must be sorted for sign

### DIFF
--- a/lib/aws4_signer/signature.rb
+++ b/lib/aws4_signer/signature.rb
@@ -87,7 +87,8 @@ class Aws4Signer
       @canonical_request ||= [
         @verb.upcase,
         @uri.path,
-        @uri.query,
+        @uri.query.split('&').map { |x| x.split('=') }.sort_by(&:first)
+                             .map { |x| x.join('=') }.join('&'),
         canonical_headers,
         signed_headers,
         hashed_payload,


### PR DESCRIPTION
Hi @sorah ,

A query must be sorted for sign,
otherwise it does not with grape_api_signature 0.0.6.

>> The parameters must be sorted by name.
http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html

Thanks.